### PR TITLE
fix!: Ensure project works with different streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ Sink your streams.
 ## Usage
 
 ```js
-var from = require('from2');
-var through = require('through2');
+var { Readable, Transform } = require('streamx');
 var sink = require('lead');
 
 // Might be used as a Transform or Writeable
-var maybeThrough = through(function (chunk, enc, cb) {
-  // processing
-  cb(null, chunk);
+var maybeThrough = new Transform({
+  transform(chunk, cb) {
+    // processing
+    cb(null, chunk);
+  },
 });
 
-from(['hello', 'world'])
+Readable.from(['hello', 'world'])
   // Sink it to behave like a Writeable
   .pipe(sink(maybeThrough));
 ```

--- a/index.js
+++ b/index.js
@@ -34,11 +34,12 @@ function sink(stream) {
     if (hasListeners(stream)) {
       sinkAdded = false;
     }
+
+    process.nextTick(addSink);
   }
 
   stream.on('newListener', removeSink);
   stream.on('removeListener', removeSink);
-  stream.on('removeListener', addSink);
 
   // Sink the stream to start flowing
   // Do this on nextTick, it will flow at slowest speed of piped streams

--- a/index.js
+++ b/index.js
@@ -16,12 +16,6 @@ function sink(stream) {
       return;
     }
 
-    // This is a streamx implementation detail
-    // TODO: Mabye upstream as `isActive`?
-    if (stream._readableState.pipeTo) {
-      return;
-    }
-
     sinkAdded = true;
     stream.resume();
   }
@@ -38,8 +32,13 @@ function sink(stream) {
     process.nextTick(addSink);
   }
 
+  function markSink() {
+    sinkAdded = true;
+  }
+
   stream.on('newListener', removeSink);
   stream.on('removeListener', removeSink);
+  stream.on('piping', markSink);
 
   // Sink the stream to start flowing
   // Do this on nextTick, it will flow at slowest speed of piped streams

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ function sink(stream) {
       return;
     }
 
+    // This is a streamx implementation detail
+    // TODO: Mabye upstream as `isActive`?
+    if (stream._readableState.pipeTo) {
+      return;
+    }
+
     sinkAdded = true;
     stream.pipe(sinkStream);
   }

--- a/index.js
+++ b/index.js
@@ -2,12 +2,8 @@
 
 var Writable = require('streamx').Writable;
 
-function listenerCount(stream, evt) {
-  return stream.listeners(evt).length;
-}
-
 function hasListeners(stream) {
-  return !!(listenerCount(stream, 'readable') || listenerCount(stream, 'data'));
+  return !!(stream.listenerCount('readable') || stream.listenerCount('data'));
 }
 
 function sink(stream) {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,11 @@
 'use strict';
 
-var Writable = require('streamx').Writable;
-
 function hasListeners(stream) {
   return !!(stream.listenerCount('readable') || stream.listenerCount('data'));
 }
 
 function sink(stream) {
   var sinkAdded = false;
-
-  var sinkStream = new Writable();
 
   function addSink() {
     if (sinkAdded) {
@@ -27,7 +23,7 @@ function sink(stream) {
     }
 
     sinkAdded = true;
-    stream.pipe(sinkStream);
+    stream.resume();
   }
 
   function removeSink(evt) {
@@ -37,7 +33,6 @@ function sink(stream) {
 
     if (hasListeners(stream)) {
       sinkAdded = false;
-      stream.unpipe(sinkStream);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "eslint-config-gulp": "^5.0.1",
     "eslint-plugin-node": "^11.1.0",
     "expect": "^27.4.2",
-    "mississippi": "^4.0.0",
     "mocha": "^8.4.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "readable-stream": "^3.6.0"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "pretest": "npm run lint",
     "test": "nyc mocha --async-only"
   },
-  "dependencies": {
-    "streamx": "^2.12.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-gulp": "^5.0.1",
@@ -31,7 +29,8 @@
     "expect": "^27.4.2",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0",
-    "readable-stream": "^3.6.0"
+    "readable-stream": "^3.6.0",
+    "streamx": "^2.12.0"
   },
   "nyc": {
     "reporter": [

--- a/test/index.js
+++ b/test/index.js
@@ -1,275 +1,261 @@
 'use strict';
 
 var expect = require('expect');
-var miss = require('mississippi');
 
 var sink = require('../');
 
-var to = miss.to;
-var from = miss.from;
-var pipe = miss.pipe;
-var through = miss.through;
-
 function noop() {}
 
-function count(value) {
-  var count = 0;
-  return through.obj(
-    function (file, enc, cb) {
-      count++;
-      cb(null, file);
-    },
-    function (cb) {
-      expect(count).toEqual(value);
-      cb();
-    }
-  );
-}
+suite('stream');
+suite('streamx');
+suite('readable-stream');
 
-function slowCount(value) {
-  var count = 0;
-  return to.obj(
-    function (file, enc, cb) {
-      count++;
+function suite(moduleName) {
+  var stream = require(moduleName);
 
-      setTimeout(function () {
+  function count(value) {
+    var count = 0;
+    return new stream.Transform({
+      objectMode: true,
+      transform: function (file, enc, cb) {
+        if (typeof enc === 'function') {
+          cb = enc;
+        }
+
+        count++;
         cb(null, file);
-      }, 250);
-    },
-    function (cb) {
-      expect(count).toEqual(value);
-      cb();
+      },
+      flush: function (cb) {
+        expect(count).toEqual(value);
+        cb();
+      },
+    });
+  }
+
+  function slowCount(value) {
+    var count = 0;
+    return new stream.Writable({
+      objectMode: true,
+      write: function (file, enc, cb) {
+        if (typeof enc === 'function') {
+          cb = enc;
+        }
+
+        count++;
+
+        setTimeout(function () {
+          cb(null, file);
+        }, 250);
+      },
+      flush: function (cb) {
+        expect(count).toEqual(value);
+        cb();
+      },
+    });
+  }
+  describe('lead (' + moduleName + ')', function () {
+    it('can wrap binary stream', function (done) {
+      var write = sink(new stream.PassThrough());
+
+      function assert(err) {
+        // Forced an object through a non-object stream
+        expect(err).toBeFalsy();
+        done();
+      }
+
+      stream.pipeline([stream.Readable.from(['1', '2', '3']), write], assert);
+    });
+
+    it('can wrap object stream', function (done) {
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      function assert(err) {
+        // Forced an object through a non-object stream
+        expect(err).toBeFalsy();
+        done();
+      }
+
+      stream.pipeline([stream.Readable.from([{}, {}, {}]), write], assert);
+    });
+
+    if (moduleName !== 'streamx') {
+      it('does not convert between object and binary stream', function (done) {
+        var write = sink(new stream.PassThrough());
+
+        // TODO: Node core stream seems to have changed something here
+        function assert(err) {
+          // Forced an object through a non-object stream
+          expect(err).toBeTruthy();
+          done();
+        }
+
+        stream.pipeline([stream.Readable.from([{}, {}, {}]), write], assert);
+      });
+    } else {
+      // Streamx does automatic conversion between object and binary streams
+      it('converts between object and binary stream', function (done) {
+        var write = sink(new stream.PassThrough());
+
+        function assert(err) {
+          expect(err).toBeFalsy();
+          done();
+        }
+
+        stream.pipeline(
+          [
+            stream.Readable.from([{}, {}, {}]),
+            // Must be in the Writable position to test this
+            // So concat-stream cannot be used
+            write,
+          ],
+          assert
+        );
+      });
     }
-  );
+
+    it('does not get clogged by highWaterMark', function (done) {
+      var expectedCount = 17;
+      var highwatermarkObjs = [];
+      for (var idx = 0; idx < expectedCount; idx++) {
+        highwatermarkObjs.push({});
+      }
+
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      stream.pipeline(
+        [stream.Readable.from(highwatermarkObjs), count(expectedCount), write],
+        done
+      );
+    });
+
+    it('allows backpressure when piped to another, slower stream', function (done) {
+      this.timeout(20000);
+
+      var expectedCount = 24;
+      var highwatermarkObjs = [];
+      for (var idx = 0; idx < expectedCount; idx++) {
+        highwatermarkObjs.push({});
+      }
+
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      stream.pipeline(
+        [
+          stream.Readable.from(highwatermarkObjs),
+          count(expectedCount),
+          write,
+          slowCount(expectedCount),
+        ],
+        done
+      );
+    });
+
+    it('respects readable listeners on wrapped stream', function (done) {
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      var readables = 0;
+      write.on('readable', function () {
+        while (write.read()) {
+          readables++;
+        }
+      });
+
+      function assert(err) {
+        expect(readables).toEqual(1);
+        done(err);
+      }
+
+      stream.pipeline([stream.Readable.from([{}]), write], assert);
+    });
+
+    it('respects data listeners on wrapped stream', function (done) {
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      var datas = 0;
+      write.on('data', function () {
+        datas++;
+      });
+
+      function assert(err) {
+        expect(datas).toEqual(1);
+        done(err);
+      }
+
+      stream.pipeline([stream.Readable.from([{}]), write], assert);
+    });
+
+    it('sinks the stream if all the readable event handlers are removed', function (done) {
+      var expectedCount = 17;
+      var highwatermarkObjs = [];
+      for (var idx = 0; idx < expectedCount; idx++) {
+        highwatermarkObjs.push({});
+      }
+
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      write.on('readable', noop);
+
+      stream.pipeline(
+        [stream.Readable.from(highwatermarkObjs), count(expectedCount), write],
+        done
+      );
+
+      process.nextTick(function () {
+        write.removeListener('readable', noop);
+      });
+    });
+
+    it('does not sink the stream if an event handler still exists when one is removed', function (done) {
+      var expectedCount = 17;
+      var highwatermarkObjs = [];
+      for (var idx = 0; idx < expectedCount; idx++) {
+        highwatermarkObjs.push({});
+      }
+
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      write.on('readable', noop);
+      var readables = 0;
+      write.on('readable', function () {
+        while (write.read()) {
+          readables++;
+        }
+      });
+
+      function assert(err) {
+        expect(readables).toEqual(expectedCount);
+        done(err);
+      }
+
+      stream.pipeline(
+        [stream.Readable.from(highwatermarkObjs), count(expectedCount), write],
+        assert
+      );
+
+      process.nextTick(function () {
+        write.removeListener('readable', noop);
+      });
+    });
+
+    it('sinks the stream if all the data event handlers are removed', function (done) {
+      var expectedCount = 17;
+      var highwatermarkObjs = [];
+      for (var idx = 0; idx < expectedCount; idx++) {
+        highwatermarkObjs.push({});
+      }
+
+      var write = sink(new stream.PassThrough({ objectMode: true }));
+
+      write.on('data', noop);
+
+      stream.pipeline(
+        [stream.Readable.from(highwatermarkObjs), count(expectedCount), write],
+        done
+      );
+
+      process.nextTick(function () {
+        write.removeListener('data', noop);
+      });
+    });
+  });
 }
-
-describe('lead', function () {
-  it('can wrap binary stream', function (done) {
-    var write = sink(through());
-
-    function assert(err) {
-      // Forced an object through a non-object stream
-      expect(err).toBeFalsy();
-      done();
-    }
-
-    pipe(
-      [
-        from(['1', '2', '3']),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      assert
-    );
-  });
-
-  it('can wrap object stream', function (done) {
-    var write = sink(through.obj());
-
-    function assert(err) {
-      // Forced an object through a non-object stream
-      expect(err).toBeFalsy();
-      done();
-    }
-
-    pipe(
-      [
-        from.obj([{}, {}, {}]),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      assert
-    );
-  });
-
-  it('does not convert between object and binary stream', function (done) {
-    var write = sink(through());
-
-    function assert(err) {
-      // Forced an object through a non-object stream
-      expect(err).toBeTruthy();
-      done();
-    }
-
-    pipe(
-      [
-        from.obj([{}, {}, {}]),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      assert
-    );
-  });
-
-  it('does not get clogged by highWaterMark', function (done) {
-    var expectedCount = 17;
-    var highwatermarkObjs = [];
-    for (var idx = 0; idx < expectedCount; idx++) {
-      highwatermarkObjs.push({});
-    }
-
-    var write = sink(through.obj());
-
-    pipe(
-      [
-        from.obj(highwatermarkObjs),
-        count(expectedCount),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      done
-    );
-  });
-
-  it('allows backpressure when piped to another, slower stream', function (done) {
-    this.timeout(20000);
-
-    var expectedCount = 24;
-    var highwatermarkObjs = [];
-    for (var idx = 0; idx < expectedCount; idx++) {
-      highwatermarkObjs.push({});
-    }
-
-    var write = sink(through.obj());
-
-    pipe(
-      [
-        from.obj(highwatermarkObjs),
-        count(expectedCount),
-        write,
-        slowCount(expectedCount),
-      ],
-      done
-    );
-  });
-
-  it('respects readable listeners on wrapped stream', function (done) {
-    var write = sink(through.obj());
-
-    var readables = 0;
-    write.on('readable', function () {
-      while (write.read()) {
-        readables++;
-      }
-    });
-
-    function assert(err) {
-      expect(readables).toEqual(1);
-      done(err);
-    }
-
-    pipe([from.obj([{}]), write], assert);
-  });
-
-  it('respects data listeners on wrapped stream', function (done) {
-    var write = sink(through.obj());
-
-    var datas = 0;
-    write.on('data', function () {
-      datas++;
-    });
-
-    function assert(err) {
-      expect(datas).toEqual(1);
-      done(err);
-    }
-
-    pipe([from.obj([{}]), write], assert);
-  });
-
-  it('sinks the stream if all the readable event handlers are removed', function (done) {
-    var expectedCount = 17;
-    var highwatermarkObjs = [];
-    for (var idx = 0; idx < expectedCount; idx++) {
-      highwatermarkObjs.push({});
-    }
-
-    var write = sink(through.obj());
-
-    write.on('readable', noop);
-
-    pipe(
-      [
-        from.obj(highwatermarkObjs),
-        count(expectedCount),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      done
-    );
-
-    process.nextTick(function () {
-      write.removeListener('readable', noop);
-    });
-  });
-
-  it('does not sink the stream if an event handler still exists when one is removed', function (done) {
-    var expectedCount = 17;
-    var highwatermarkObjs = [];
-    for (var idx = 0; idx < expectedCount; idx++) {
-      highwatermarkObjs.push({});
-    }
-
-    var write = sink(through.obj());
-
-    write.on('readable', noop);
-    var readables = 0;
-    write.on('readable', function () {
-      while (write.read()) {
-        readables++;
-      }
-    });
-
-    function assert(err) {
-      expect(readables).toEqual(expectedCount);
-      done(err);
-    }
-
-    pipe(
-      [
-        from.obj(highwatermarkObjs),
-        count(expectedCount),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      assert
-    );
-
-    process.nextTick(function () {
-      write.removeListener('readable', noop);
-    });
-  });
-
-  it('sinks the stream if all the data event handlers are removed', function (done) {
-    var expectedCount = 17;
-    var highwatermarkObjs = [];
-    for (var idx = 0; idx < expectedCount; idx++) {
-      highwatermarkObjs.push({});
-    }
-
-    var write = sink(through.obj());
-
-    write.on('data', noop);
-
-    pipe(
-      [
-        from.obj(highwatermarkObjs),
-        count(expectedCount),
-        // Must be in the Writable position to test this
-        // So concat-stream cannot be used
-        write,
-      ],
-      done
-    );
-
-    process.nextTick(function () {
-      write.removeListener('data', noop);
-    });
-  });
-});

--- a/test/index.js
+++ b/test/index.js
@@ -79,10 +79,20 @@ function suite(moduleName) {
     });
 
     if (moduleName !== 'streamx') {
+      // TODO: Remove this test when we drop node <15
       it('does not convert between object and binary stream', function (done) {
+        // Node core made a terrible decision in https://github.com/nodejs/node/pull/31831
+        // and decided to start throwing on invalid encoding types, so we skip this test
+        if (
+          process.version.startsWith('v14') ||
+          process.version.startsWith('v16')
+        ) {
+          this.skip();
+          return;
+        }
+
         var write = sink(new stream.PassThrough());
 
-        // TODO: Node core stream seems to have changed something here
         function assert(err) {
           // Forced an object through a non-object stream
           expect(err).toBeTruthy();


### PR DESCRIPTION
Once I finish getting all these tests to pass, this closes #5 - as I believe it was trying to determine if various types of streams would work with this project. @coreyfarrell can correct me if I am wrong.

I found that streamx streams actually can't be used with `lead` and I am trying to account for the differences. This will rely on https://github.com/streamxorg/streamx/issues/11 and probably an `isFlowing` function as mentioned in https://github.com/streamxorg/streamx/issues/16

It also seems that the node core streams have broken one of the test and I want to see which version broke that.

I've also updated the example in the readme so this closes #7 when it lands.