### PR TITLE
chore: Normalize repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/lead.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/lead/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/lead/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/lead/dev.yml?branch=master&style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/lead
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/lead/master.svg?style=flat-square


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by badges/shields's issue `#8671`.
This PR modifies the URL in `README.md`.